### PR TITLE
Add JWT cookie auth and user CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# UMS Backend
+
+Spring Boot User Management service with cookie-based JWT auth and PostgreSQL.
+
+## Quick Start
+
+Ensure PostgreSQL is running (Docker compose already includes it) and the database has the required schema and seed data.
+
+```bash
+mvn clean package
+mvn spring-boot:run
+```
+
+## cURL Examples
+
+### Login (store cookie)
+```bash
+curl -i -c cookie.txt -X POST http://localhost:8080/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"admin@123"}'
+```
+
+### Me (reads cookie)
+```bash
+curl -b cookie.txt http://localhost:8080/auth/me
+```
+
+### Create user
+```bash
+curl -b cookie.txt -X POST http://localhost:8080/users \
+  -H "Content-Type: application/json" \
+  -d '{"username":"alice","password":"alice@123","statusCode":"active"}'
+```
+
+### List users
+```bash
+curl -b cookie.txt "http://localhost:8080/users?page=0&size=10"
+```
+
+### Update user
+```bash
+curl -b cookie.txt -X PATCH http://localhost:8080/users/2 \
+  -H "Content-Type: application/json" \
+  -d '{"password":"newStrongPass"}'
+```
+
+### Soft delete
+```bash
+curl -b cookie.txt -X DELETE http://localhost:8080/users/2
+```
+
+### Logout (clears cookie)
+```bash
+curl -b cookie.txt -X POST http://localhost:8080/auth/logout
+```

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
+        <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>3.3.2</version>
+                <relativePath/>
+        </parent>
 	<groupId>com.example</groupId>
 	<artifactId>ums</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
@@ -29,18 +29,51 @@
 	<properties>
 		<java.version>21</java.version>
 	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
+        <dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-validation</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-api</artifactId>
+                        <version>0.12.5</version>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-impl</artifactId>
+                        <version>0.12.5</version>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-jackson</artifactId>
+                        <version>0.12.5</version>
+                        <scope>runtime</scope>
+                </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/example/ums/UmsApplication.java
+++ b/src/main/java/com/example/ums/UmsApplication.java
@@ -2,8 +2,10 @@ package com.example.ums;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class UmsApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/ums/config/AuthCookieProperties.java
+++ b/src/main/java/com/example/ums/config/AuthCookieProperties.java
@@ -1,0 +1,31 @@
+package com.example.ums.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.auth.cookie")
+public class AuthCookieProperties {
+    private String name;
+    private String domain;
+    private String path;
+    private boolean secure;
+    private boolean httpOnly;
+    private String sameSite;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getDomain() { return domain; }
+    public void setDomain(String domain) { this.domain = domain; }
+
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+
+    public boolean isSecure() { return secure; }
+    public void setSecure(boolean secure) { this.secure = secure; }
+
+    public boolean isHttpOnly() { return httpOnly; }
+    public void setHttpOnly(boolean httpOnly) { this.httpOnly = httpOnly; }
+
+    public String getSameSite() { return sameSite; }
+    public void setSameSite(String sameSite) { this.sameSite = sameSite; }
+}

--- a/src/main/java/com/example/ums/config/JwtProperties.java
+++ b/src/main/java/com/example/ums/config/JwtProperties.java
@@ -1,0 +1,25 @@
+package com.example.ums.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.jwt")
+public class JwtProperties {
+    private String secret;
+    private long expirationMinutes;
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public long getExpirationMinutes() {
+        return expirationMinutes;
+    }
+
+    public void setExpirationMinutes(long expirationMinutes) {
+        this.expirationMinutes = expirationMinutes;
+    }
+}

--- a/src/main/java/com/example/ums/config/SecurityConfig.java
+++ b/src/main/java/com/example/ums/config/SecurityConfig.java
@@ -1,0 +1,69 @@
+package com.example.ums.config;
+
+import com.example.ums.security.JwtAuthFilter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class SecurityConfig {
+    private final JwtAuthFilter jwtAuthFilter;
+
+    public SecurityConfig(JwtAuthFilter jwtAuthFilter) {
+        this.jwtAuthFilter = jwtAuthFilter;
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .cors(Customizer.withDefaults())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/logout").permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/auth/me").authenticated()
+                        .requestMatchers("/users/**").authenticated()
+                        .anyRequest().permitAll()
+                )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource(@Value("${CORS_ORIGINS:*}") String origins) {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        if (origins == null || origins.isBlank() || origins.equals("*")) {
+            config.addAllowedOriginPattern("*");
+        } else {
+            for (String o : origins.split(",")) {
+                config.addAllowedOrigin(o.trim());
+            }
+        }
+        config.addAllowedHeader("Content-Type");
+        config.addAllowedHeader("Authorization");
+        config.addAllowedMethod("GET");
+        config.addAllowedMethod("POST");
+        config.addAllowedMethod("PUT");
+        config.addAllowedMethod("PATCH");
+        config.addAllowedMethod("DELETE");
+        config.addAllowedMethod("OPTIONS");
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/java/com/example/ums/controller/AuthController.java
+++ b/src/main/java/com/example/ums/controller/AuthController.java
@@ -1,0 +1,52 @@
+package com.example.ums.controller;
+
+import com.example.ums.dto.LoginRequest;
+import com.example.ums.dto.LoginResponse;
+import com.example.ums.dto.UserInfo;
+import com.example.ums.security.AuthUser;
+import com.example.ums.security.CookieUtil;
+import com.example.ums.service.AuthService;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+    private final CookieUtil cookieUtil;
+
+    public AuthController(AuthService authService, CookieUtil cookieUtil) {
+        this.authService = authService;
+        this.cookieUtil = cookieUtil;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request, HttpServletResponse response) {
+        LoginResponse result = authService.login(request.username(), request.password());
+        ResponseCookie cookie = cookieUtil.buildAuthCookie(result.token());
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/me")
+    public UserInfo me(Authentication authentication) {
+        if (authentication == null || !(authentication.getPrincipal() instanceof AuthUser user)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return authService.getUserInfo(user.id());
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
+        ResponseCookie cookie = cookieUtil.buildDeletionCookie();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/ums/controller/UsersController.java
+++ b/src/main/java/com/example/ums/controller/UsersController.java
@@ -1,0 +1,50 @@
+package com.example.ums.controller;
+
+import com.example.ums.dto.*;
+import com.example.ums.security.AuthUser;
+import com.example.ums.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+public class UsersController {
+    private final UserService userService;
+
+    public UsersController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    public PagedResponse<UserResponse> list(Pageable pageable) {
+        return userService.list(pageable);
+    }
+
+    @GetMapping("/{id}")
+    public UserResponse get(@PathVariable Long id) {
+        return userService.get(id);
+    }
+
+    @PostMapping
+    public UserResponse create(@Valid @RequestBody UserCreateRequest req, Authentication auth) {
+        AuthUser user = (AuthUser) auth.getPrincipal();
+        return userService.create(req, user.id());
+    }
+
+    @PutMapping("/{id}")
+    @PatchMapping("/{id}")
+    public UserResponse update(@PathVariable Long id, @RequestBody UserUpdateRequest req, Authentication auth) {
+        AuthUser user = (AuthUser) auth.getPrincipal();
+        return userService.update(id, req, user.id());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id, Authentication auth) {
+        AuthUser user = (AuthUser) auth.getPrincipal();
+        userService.delete(id, user.id());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/ums/dto/LoginRequest.java
+++ b/src/main/java/com/example/ums/dto/LoginRequest.java
@@ -1,0 +1,5 @@
+package com.example.ums.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(@NotBlank String username, @NotBlank String password) {}

--- a/src/main/java/com/example/ums/dto/LoginResponse.java
+++ b/src/main/java/com/example/ums/dto/LoginResponse.java
@@ -1,0 +1,3 @@
+package com.example.ums.dto;
+
+public record LoginResponse(String token, UserInfo user) {}

--- a/src/main/java/com/example/ums/dto/PagedResponse.java
+++ b/src/main/java/com/example/ums/dto/PagedResponse.java
@@ -1,0 +1,5 @@
+package com.example.ums.dto;
+
+import java.util.List;
+
+public record PagedResponse<T>(List<T> items, int page, int size, long total) {}

--- a/src/main/java/com/example/ums/dto/UserCreateRequest.java
+++ b/src/main/java/com/example/ums/dto/UserCreateRequest.java
@@ -1,0 +1,5 @@
+package com.example.ums.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserCreateRequest(@NotBlank String username, @NotBlank String password, String statusCode) {}

--- a/src/main/java/com/example/ums/dto/UserInfo.java
+++ b/src/main/java/com/example/ums/dto/UserInfo.java
@@ -1,0 +1,5 @@
+package com.example.ums.dto;
+
+import java.time.Instant;
+
+public record UserInfo(Long id, String username, String status, Instant lastLoginAt) {}

--- a/src/main/java/com/example/ums/dto/UserResponse.java
+++ b/src/main/java/com/example/ums/dto/UserResponse.java
@@ -1,0 +1,5 @@
+package com.example.ums.dto;
+
+import java.time.Instant;
+
+public record UserResponse(Long id, String username, String status, Instant lastLoginAt, Instant createdAt, Instant updatedAt) {}

--- a/src/main/java/com/example/ums/dto/UserUpdateRequest.java
+++ b/src/main/java/com/example/ums/dto/UserUpdateRequest.java
@@ -1,0 +1,3 @@
+package com.example.ums.dto;
+
+public record UserUpdateRequest(String username, String password, String statusCode) {}

--- a/src/main/java/com/example/ums/entity/StatusCodeEntity.java
+++ b/src/main/java/com/example/ums/entity/StatusCodeEntity.java
@@ -1,0 +1,40 @@
+package com.example.ums.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(schema = "ums", name = "status_codes")
+public class StatusCodeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Short id;
+
+    @Column(name = "domain")
+    private String domain;
+
+    @Column(name = "code")
+    private String code;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "is_active")
+    private Boolean isActive;
+
+    @Column(name = "sort_order")
+    private Integer sortOrder;
+
+    public Short getId() { return id; }
+    public void setId(Short id) { this.id = id; }
+    public String getDomain() { return domain; }
+    public void setDomain(String domain) { this.domain = domain; }
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public Boolean getIsActive() { return isActive; }
+    public void setIsActive(Boolean isActive) { this.isActive = isActive; }
+    public Integer getSortOrder() { return sortOrder; }
+    public void setSortOrder(Integer sortOrder) { this.sortOrder = sortOrder; }
+}

--- a/src/main/java/com/example/ums/entity/UserEntity.java
+++ b/src/main/java/com/example/ums/entity/UserEntity.java
@@ -1,0 +1,79 @@
+package com.example.ums.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(schema = "ums", name = "users")
+public class UserEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "username")
+    private String username;
+
+    @JsonIgnore
+    @Column(name = "password_hash")
+    private String passwordHash;
+
+    @Column(name = "status_id")
+    private Short statusId;
+
+    @Column(name = "failed_login_attempts")
+    private Integer failedLoginAttempts;
+
+    @Column(name = "last_login_at")
+    private Instant lastLoginAt;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @Column(name = "created_by")
+    private Long createdBy;
+
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getPasswordHash() { return passwordHash; }
+    public void setPasswordHash(String passwordHash) { this.passwordHash = passwordHash; }
+
+    public Short getStatusId() { return statusId; }
+    public void setStatusId(Short statusId) { this.statusId = statusId; }
+
+    public Integer getFailedLoginAttempts() { return failedLoginAttempts; }
+    public void setFailedLoginAttempts(Integer failedLoginAttempts) { this.failedLoginAttempts = failedLoginAttempts; }
+
+    public Instant getLastLoginAt() { return lastLoginAt; }
+    public void setLastLoginAt(Instant lastLoginAt) { this.lastLoginAt = lastLoginAt; }
+
+    public Instant getDeletedAt() { return deletedAt; }
+    public void setDeletedAt(Instant deletedAt) { this.deletedAt = deletedAt; }
+
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    public Instant getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+
+    public Long getCreatedBy() { return createdBy; }
+    public void setCreatedBy(Long createdBy) { this.createdBy = createdBy; }
+
+    public Long getUpdatedBy() { return updatedBy; }
+    public void setUpdatedBy(Long updatedBy) { this.updatedBy = updatedBy; }
+}

--- a/src/main/java/com/example/ums/exception/ErrorResponse.java
+++ b/src/main/java/com/example/ums/exception/ErrorResponse.java
@@ -1,0 +1,5 @@
+package com.example.ums.exception;
+
+import java.time.Instant;
+
+public record ErrorResponse(String error, String message, String path, Instant timestamp) {}

--- a/src/main/java/com/example/ums/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/ums/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.example.ums.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponse> handle(ResponseStatusException ex, HttpServletRequest req) {
+        ErrorResponse body = new ErrorResponse(ex.getStatusCode().toString(), ex.getReason(), req.getRequestURI(), Instant.now());
+        return ResponseEntity.status(ex.getStatusCode()).body(body);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest req) {
+        String msg = ex.getBindingResult().getFieldErrors().stream()
+                .findFirst().map(f -> f.getField() + ": " + f.getDefaultMessage())
+                .orElse("Validation error");
+        ErrorResponse body = new ErrorResponse(HttpStatus.BAD_REQUEST.toString(), msg, req.getRequestURI(), Instant.now());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+}

--- a/src/main/java/com/example/ums/repo/StatusCodeRepository.java
+++ b/src/main/java/com/example/ums/repo/StatusCodeRepository.java
@@ -1,0 +1,10 @@
+package com.example.ums.repo;
+
+import com.example.ums.entity.StatusCodeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StatusCodeRepository extends JpaRepository<StatusCodeEntity, Short> {
+    Optional<StatusCodeEntity> findByDomainAndCode(String domain, String code);
+}

--- a/src/main/java/com/example/ums/repo/UserRepository.java
+++ b/src/main/java/com/example/ums/repo/UserRepository.java
@@ -1,0 +1,15 @@
+package com.example.ums.repo;
+
+import com.example.ums.entity.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findByUsernameIgnoreCase(String username);
+    Optional<UserEntity> findByIdAndDeletedAtIsNull(Long id);
+    Page<UserEntity> findAllByDeletedAtIsNull(Pageable pageable);
+    boolean existsByUsernameIgnoreCase(String username);
+}

--- a/src/main/java/com/example/ums/security/AuthUser.java
+++ b/src/main/java/com/example/ums/security/AuthUser.java
@@ -1,0 +1,3 @@
+package com.example.ums.security;
+
+public record AuthUser(Long id, String username) {}

--- a/src/main/java/com/example/ums/security/CookieUtil.java
+++ b/src/main/java/com/example/ums/security/CookieUtil.java
@@ -1,0 +1,55 @@
+package com.example.ums.security;
+
+import com.example.ums.config.AuthCookieProperties;
+import com.example.ums.config.JwtProperties;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+public class CookieUtil {
+    private final AuthCookieProperties cookieProps;
+    private final JwtProperties jwtProps;
+
+    public CookieUtil(AuthCookieProperties cookieProps, JwtProperties jwtProps) {
+        this.cookieProps = cookieProps;
+        this.jwtProps = jwtProps;
+    }
+
+    public ResponseCookie buildAuthCookie(String token) {
+        return ResponseCookie.from(cookieProps.getName(), token)
+                .domain(cookieProps.getDomain())
+                .path(cookieProps.getPath())
+                .httpOnly(cookieProps.isHttpOnly())
+                .secure(cookieProps.isSecure())
+                .sameSite(cookieProps.getSameSite())
+                .maxAge(Duration.ofMinutes(jwtProps.getExpirationMinutes()))
+                .build();
+    }
+
+    public ResponseCookie buildDeletionCookie() {
+        return ResponseCookie.from(cookieProps.getName(), "")
+                .domain(cookieProps.getDomain())
+                .path(cookieProps.getPath())
+                .httpOnly(cookieProps.isHttpOnly())
+                .secure(cookieProps.isSecure())
+                .sameSite(cookieProps.getSameSite())
+                .maxAge(0)
+                .build();
+    }
+
+    public Optional<String> readAuthCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(c -> c.getName().equals(cookieProps.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
+}

--- a/src/main/java/com/example/ums/security/JwtAuthFilter.java
+++ b/src/main/java/com/example/ums/security/JwtAuthFilter.java
@@ -1,0 +1,48 @@
+package com.example.ums.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
+
+    public JwtAuthFilter(JwtUtil jwtUtil, CookieUtil cookieUtil) {
+        this.jwtUtil = jwtUtil;
+        this.cookieUtil = cookieUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        cookieUtil.readAuthCookie(request).ifPresent(token -> {
+            try {
+                Jws<Claims> jws = jwtUtil.parse(token);
+                if (!jwtUtil.isExpired(jws)) {
+                    Long uid = jws.getPayload().get("uid", Long.class);
+                    String uname = jws.getPayload().get("uname", String.class);
+                    AuthUser principal = new AuthUser(uid, uname);
+                    UsernamePasswordAuthenticationToken auth =
+                            new UsernamePasswordAuthenticationToken(principal, null, null);
+                    auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                }
+            } catch (Exception ignored) {
+                // Invalid token - ignore
+            }
+        });
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/ums/security/JwtUtil.java
+++ b/src/main/java/com/example/ums/security/JwtUtil.java
@@ -1,0 +1,50 @@
+package com.example.ums.security;
+
+import com.example.ums.config.JwtProperties;
+import com.example.ums.entity.UserEntity;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+    private final JwtProperties props;
+
+    public JwtUtil(JwtProperties props) {
+        this.props = props;
+    }
+
+    public String generateToken(UserEntity user) {
+        Instant now = Instant.now();
+        Instant exp = now.plus(props.getExpirationMinutes(), ChronoUnit.MINUTES);
+        return Jwts.builder()
+                .subject(user.getId() + ":" + user.getUsername())
+                .claim("uid", user.getId())
+                .claim("uname", user.getUsername())
+                .claim("status", user.getStatusId())
+                .expiration(Date.from(exp))
+                .issuedAt(Date.from(now))
+                .signWith(Keys.hmacShaKeyFor(props.getSecret().getBytes(StandardCharsets.UTF_8)))
+                .compact();
+    }
+
+    public Jws<Claims> parse(String token) {
+        return Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(props.getSecret().getBytes(StandardCharsets.UTF_8)))
+                .build()
+                .parseSignedClaims(token);
+    }
+
+    public boolean isExpired(Jws<Claims> jws) {
+        Date exp = jws.getPayload().getExpiration();
+        return exp.before(new Date());
+    }
+}

--- a/src/main/java/com/example/ums/service/AuthService.java
+++ b/src/main/java/com/example/ums/service/AuthService.java
@@ -1,0 +1,87 @@
+package com.example.ums.service;
+
+import com.example.ums.dto.LoginResponse;
+import com.example.ums.dto.UserInfo;
+import com.example.ums.entity.StatusCodeEntity;
+import com.example.ums.entity.UserEntity;
+import com.example.ums.repo.StatusCodeRepository;
+import com.example.ums.repo.UserRepository;
+import com.example.ums.security.JwtUtil;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Service
+public class AuthService {
+    private static final int LOCK_THRESHOLD = 5;
+
+    private static final Logger log = LoggerFactory.getLogger(AuthService.class);
+
+    private final UserRepository userRepository;
+    private final StatusCodeRepository statusCodeRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    public AuthService(UserRepository userRepository, StatusCodeRepository statusCodeRepository,
+                       BCryptPasswordEncoder passwordEncoder, JwtUtil jwtUtil) {
+        this.userRepository = userRepository;
+        this.statusCodeRepository = statusCodeRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Transactional
+    public LoginResponse login(String username, String password) {
+        UserEntity user = userRepository.findByUsernameIgnoreCase(username)
+                .filter(u -> u.getDeletedAt() == null)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid credentials"));
+
+        String statusCode = statusCodeRepository.findById(user.getStatusId())
+                .map(StatusCodeEntity::getCode).orElse(null);
+        if ("inactive".equalsIgnoreCase(statusCode)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User inactive");
+        }
+        if ("locked".equalsIgnoreCase(statusCode)) {
+            throw new ResponseStatusException(HttpStatus.LOCKED, "Account locked");
+        }
+
+        if (passwordEncoder.matches(password, user.getPasswordHash())) {
+            user.setFailedLoginAttempts(0);
+            user.setLastLoginAt(Instant.now());
+            userRepository.save(user);
+            String token = jwtUtil.generateToken(user);
+            UserInfo info = UserMapper.toInfo(user, statusCode);
+            log.info("Login success for {}", username);
+            return new LoginResponse(token, info);
+        } else {
+            int attempts = Optional.ofNullable(user.getFailedLoginAttempts()).orElse(0) + 1;
+            user.setFailedLoginAttempts(attempts);
+            if (attempts >= LOCK_THRESHOLD) {
+                Short lockedId = statusCodeRepository.findByDomainAndCode("ums", "locked")
+                        .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Missing status code"))
+                        .getId();
+                user.setStatusId(lockedId);
+                log.info("User {} locked after {} failed attempts", username, attempts);
+            } else {
+                log.info("Login failed for {} attempt {}", username, attempts);
+            }
+            userRepository.save(user);
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid credentials");
+        }
+    }
+
+    public UserInfo getUserInfo(Long userId) {
+        UserEntity user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        String statusCode = statusCodeRepository.findById(user.getStatusId())
+                .map(StatusCodeEntity::getCode).orElse(null);
+        return UserMapper.toInfo(user, statusCode);
+    }
+}

--- a/src/main/java/com/example/ums/service/UserMapper.java
+++ b/src/main/java/com/example/ums/service/UserMapper.java
@@ -1,0 +1,16 @@
+package com.example.ums.service;
+
+import com.example.ums.dto.UserInfo;
+import com.example.ums.dto.UserResponse;
+import com.example.ums.entity.UserEntity;
+
+public class UserMapper {
+    public static UserInfo toInfo(UserEntity entity, String status) {
+        return new UserInfo(entity.getId(), entity.getUsername(), status, entity.getLastLoginAt());
+    }
+
+    public static UserResponse toResponse(UserEntity entity, String status) {
+        return new UserResponse(entity.getId(), entity.getUsername(), status,
+                entity.getLastLoginAt(), entity.getCreatedAt(), entity.getUpdatedAt());
+    }
+}

--- a/src/main/java/com/example/ums/service/UserService.java
+++ b/src/main/java/com/example/ums/service/UserService.java
@@ -1,0 +1,113 @@
+package com.example.ums.service;
+
+import com.example.ums.dto.*;
+import com.example.ums.entity.StatusCodeEntity;
+import com.example.ums.entity.UserEntity;
+import com.example.ums.repo.StatusCodeRepository;
+import com.example.ums.repo.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+    private final StatusCodeRepository statusCodeRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, StatusCodeRepository statusCodeRepository,
+                       BCryptPasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.statusCodeRepository = statusCodeRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public PagedResponse<UserResponse> list(Pageable pageable) {
+        Page<UserEntity> page = userRepository.findAllByDeletedAtIsNull(pageable);
+        return new PagedResponse<>(page.map(u -> {
+            String status = statusCodeRepository.findById(u.getStatusId())
+                    .map(StatusCodeEntity::getCode).orElse(null);
+            return UserMapper.toResponse(u, status);
+        }).getContent(), page.getNumber(), page.getSize(), page.getTotalElements());
+    }
+
+    public UserResponse get(Long id) {
+        UserEntity user = userRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        String status = statusCodeRepository.findById(user.getStatusId())
+                .map(StatusCodeEntity::getCode).orElse(null);
+        return UserMapper.toResponse(user, status);
+    }
+
+    @Transactional
+    public UserResponse create(UserCreateRequest req, Long currentUserId) {
+        if (userRepository.existsByUsernameIgnoreCase(req.username())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Username already exists");
+        }
+        UserEntity user = new UserEntity();
+        user.setUsername(req.username());
+        user.setPasswordHash(passwordEncoder.encode(req.password()));
+        Short statusId = resolveStatusId(req.statusCode(), "active");
+        user.setStatusId(statusId);
+        user.setFailedLoginAttempts(0);
+        Instant now = Instant.now();
+        user.setCreatedAt(now);
+        user.setUpdatedAt(now);
+        user.setCreatedBy(currentUserId);
+        user.setUpdatedBy(currentUserId);
+        userRepository.save(user);
+        String status = statusCodeRepository.findById(statusId).map(StatusCodeEntity::getCode).orElse(null);
+        return UserMapper.toResponse(user, status);
+    }
+
+    @Transactional
+    public UserResponse update(Long id, UserUpdateRequest req, Long currentUserId) {
+        UserEntity user = userRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        if (req.username() != null && !req.username().equalsIgnoreCase(user.getUsername())) {
+            if (userRepository.existsByUsernameIgnoreCase(req.username())) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "Username already exists");
+            }
+            user.setUsername(req.username());
+        }
+        if (req.password() != null) {
+            user.setPasswordHash(passwordEncoder.encode(req.password()));
+        }
+        if (req.statusCode() != null) {
+            user.setStatusId(resolveStatusId(req.statusCode(), null));
+        }
+        user.setUpdatedAt(Instant.now());
+        user.setUpdatedBy(currentUserId);
+        userRepository.save(user);
+        String status = statusCodeRepository.findById(user.getStatusId()).map(StatusCodeEntity::getCode).orElse(null);
+        return UserMapper.toResponse(user, status);
+    }
+
+    @Transactional
+    public void delete(Long id, Long currentUserId) {
+        UserEntity user = userRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        user.setDeletedAt(Instant.now());
+        Short inactiveId = resolveStatusId("inactive", "inactive");
+        user.setStatusId(inactiveId);
+        user.setUpdatedAt(Instant.now());
+        user.setUpdatedBy(currentUserId);
+        userRepository.save(user);
+    }
+
+    private Short resolveStatusId(String code, String defaultCode) {
+        String c = code != null ? code : defaultCode;
+        if (c == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Status code required");
+        }
+        return statusCodeRepository.findByDomainAndCode("ums", c)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid status code"))
+                .getId();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=ums

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,33 @@
+spring:
+  application:
+    name: ums
+  datasource:
+    url: jdbc:postgresql://localhost:5432/wms?currentSchema=ums
+    username: ums
+    password: ums
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_schema: ums
+  sql:
+    init:
+      mode: never
+server:
+  port: 8080
+
+app:
+  jwt:
+    secret: "change-me-very-long-random-secret"
+    expiration-minutes: 60
+  auth:
+    cookie:
+      name: "AUTH_TOKEN"
+      domain: ""
+      path: "/"
+      secure: false
+      httpOnly: true
+      sameSite: "Lax"


### PR DESCRIPTION
## Summary
- add Spring Security JWT cookie-based authentication
- implement Users CRUD with PostgreSQL persistence
- provide global error handling and REST controllers

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689efbf978288332b4dab0596f783f7b