### PR TITLE
Add user role support and admin login reset endpoint

### DIFF
--- a/src/main/java/com/example/ums/controller/UsersController.java
+++ b/src/main/java/com/example/ums/controller/UsersController.java
@@ -47,4 +47,10 @@ public class UsersController {
         userService.delete(id, user.id());
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/{id}/reset-failed-attempts")
+    public UserResponse resetFailedAttempts(@PathVariable Long id, Authentication auth) {
+        AuthUser user = (AuthUser) auth.getPrincipal();
+        return userService.resetFailedAttempts(id, user.id());
+    }
 }

--- a/src/main/java/com/example/ums/dto/UserCreateRequest.java
+++ b/src/main/java/com/example/ums/dto/UserCreateRequest.java
@@ -2,4 +2,5 @@ package com.example.ums.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record UserCreateRequest(@NotBlank String username, @NotBlank String password, String statusCode) {}
+public record UserCreateRequest(@NotBlank String username, @NotBlank String password,
+                                String statusCode, String roleCode) {}

--- a/src/main/java/com/example/ums/dto/UserInfo.java
+++ b/src/main/java/com/example/ums/dto/UserInfo.java
@@ -2,4 +2,4 @@ package com.example.ums.dto;
 
 import java.time.Instant;
 
-public record UserInfo(Long id, String username, String status, Instant lastLoginAt) {}
+public record UserInfo(Long id, String username, String status, String role, Instant lastLoginAt) {}

--- a/src/main/java/com/example/ums/dto/UserResponse.java
+++ b/src/main/java/com/example/ums/dto/UserResponse.java
@@ -2,4 +2,6 @@ package com.example.ums.dto;
 
 import java.time.Instant;
 
-public record UserResponse(Long id, String username, String status, Instant lastLoginAt, Instant createdAt, Instant updatedAt) {}
+public record UserResponse(Long id, String username, String status, String role,
+                           Instant lastLoginAt, Instant createdAt, Instant updatedAt) {
+}

--- a/src/main/java/com/example/ums/dto/UserUpdateRequest.java
+++ b/src/main/java/com/example/ums/dto/UserUpdateRequest.java
@@ -1,3 +1,3 @@
 package com.example.ums.dto;
 
-public record UserUpdateRequest(String username, String password, String statusCode) {}
+public record UserUpdateRequest(String username, String password, String statusCode, String roleCode) {}

--- a/src/main/java/com/example/ums/entity/UserEntity.java
+++ b/src/main/java/com/example/ums/entity/UserEntity.java
@@ -23,6 +23,9 @@ public class UserEntity {
     @Column(name = "status_id")
     private Short statusId;
 
+    @Column(name = "role_id")
+    private Short roleId;
+
     @Column(name = "failed_login_attempts")
     private Integer failedLoginAttempts;
 
@@ -55,6 +58,9 @@ public class UserEntity {
 
     public Short getStatusId() { return statusId; }
     public void setStatusId(Short statusId) { this.statusId = statusId; }
+
+    public Short getRoleId() { return roleId; }
+    public void setRoleId(Short roleId) { this.roleId = roleId; }
 
     public Integer getFailedLoginAttempts() { return failedLoginAttempts; }
     public void setFailedLoginAttempts(Integer failedLoginAttempts) { this.failedLoginAttempts = failedLoginAttempts; }

--- a/src/main/java/com/example/ums/entity/UserRoleEntity.java
+++ b/src/main/java/com/example/ums/entity/UserRoleEntity.java
@@ -1,0 +1,27 @@
+package com.example.ums.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(schema = "ums", name = "user_roles")
+public class UserRoleEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Short id;
+
+    @Column(name = "code")
+    private String code;
+
+    @Column(name = "name")
+    private String name;
+
+    public Short getId() { return id; }
+    public void setId(Short id) { this.id = id; }
+
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+}

--- a/src/main/java/com/example/ums/repo/UserRoleRepository.java
+++ b/src/main/java/com/example/ums/repo/UserRoleRepository.java
@@ -1,0 +1,10 @@
+package com.example.ums.repo;
+
+import com.example.ums.entity.UserRoleEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRoleRepository extends JpaRepository<UserRoleEntity, Short> {
+    Optional<UserRoleEntity> findByCode(String code);
+}

--- a/src/main/java/com/example/ums/service/UserMapper.java
+++ b/src/main/java/com/example/ums/service/UserMapper.java
@@ -5,12 +5,12 @@ import com.example.ums.dto.UserResponse;
 import com.example.ums.entity.UserEntity;
 
 public class UserMapper {
-    public static UserInfo toInfo(UserEntity entity, String status) {
-        return new UserInfo(entity.getId(), entity.getUsername(), status, entity.getLastLoginAt());
+    public static UserInfo toInfo(UserEntity entity, String status, String role) {
+        return new UserInfo(entity.getId(), entity.getUsername(), status, role, entity.getLastLoginAt());
     }
 
-    public static UserResponse toResponse(UserEntity entity, String status) {
-        return new UserResponse(entity.getId(), entity.getUsername(), status,
+    public static UserResponse toResponse(UserEntity entity, String status, String role) {
+        return new UserResponse(entity.getId(), entity.getUsername(), status, role,
                 entity.getLastLoginAt(), entity.getCreatedAt(), entity.getUpdatedAt());
     }
 }


### PR DESCRIPTION
## Summary
- introduce user role entity and repository
- extend user CRUD and auth flow to handle roles
- add endpoint to reset failed login attempts for admin accounts

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a4a25beca0833284faa7896e835c4d